### PR TITLE
chore: set ref required to false for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -5,11 +5,11 @@ on:
     inputs:
       compiler-tester-ref:
         type: string
-        required: true
+        required: false
         description: 'Compiler tester revision to use.'
       llvm-ref:
         type: string
-        required: true
+        required: false
         description: 'LLVM revision to use.'
       path:
         type: string


### PR DESCRIPTION
# What ❔

Set ref parameters `required` to `false`.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

It is not always mandatory to specify these parameters.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
