### PR TITLE
fix: skip cancelled jobs in benchmarks analysis

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -168,7 +168,7 @@ jobs:
     container:
       image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
     needs: benchmarks
-    if: always()
+    if: failure() || success()
     steps:
       - name: Checking out the compiler-tester repository
         uses: actions/checkout@v4


### PR DESCRIPTION
# What ❔

Do not run benchmark analysis if jobs were cancelled

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
