### PR TITLE
chore: disable PR comment for fork repositories

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -189,14 +189,14 @@ jobs:
 
       - name: Posting the LLVM benchmark results to the summary
         run: |
-          printf "Benchmark results:\n" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          cat result.txt >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          printf "Benchmark results:\n" | tee -a $GITHUB_STEP_SUMMARY
+          echo '```' | tee -a $GITHUB_STEP_SUMMARY
+          cat result.txt | tee -a $GITHUB_STEP_SUMMARY
+          echo '```' | tee -a $GITHUB_STEP_SUMMARY
           cat $GITHUB_STEP_SUMMARY > result.txt
 
       - name: Posting the LLVM benchmark results to a PR comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: mshick/add-pr-comment@v2
         with:
           message-path: result.txt


### PR DESCRIPTION
# What ❔

Disable PR commenting for the benchmark comparison if the workflow is executed from the forked repository.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

For security reasons, GitHub restricts fork repositories `GITHUB_TOKEN` in permissions setting it to `read`-only. So, for the fork repository workflows, we will print benchmark comparison to the summary and in logs, but not commenting in the PR.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
