### PR TITLE
chore: disable slack notification sending for forks

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Send Slack notification
         uses: 8398a7/action-slack@v3
-        if: ${{ failure() || success() }} # Skip canceled jobs
+        if: (failure() || success()) && (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)
         with:
           status: ${{ job.status }}
           fields: repo,commit,author,action,eventName,ref,workflow,job,took,pullRequest


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Do not send Slack notification if the workflow is running from the fork repository (external collaborators).

## Why ❔

For security reasons, GitHub restricts access to secrets for forks. So, for the fork repository we just report workflow status in Github, but Slack notification will not be sent.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
