### PR TITLE
feat: add broader cargo checks - udeps, audit, fmt, clippy, deny

### DIFF
--- a/.github/actions/cargo-check/action.yml
+++ b/.github/actions/cargo-check/action.yml
@@ -1,0 +1,41 @@
+name: 'Cargo check'
+description: 'Checks cargo with check, deny, format, clippy, udeps and audit.'
+
+inputs:
+  github_token:
+    description: 'GitHub token for cargo audit.'
+    required: true
+
+runs:
+  using: composite
+  steps:
+
+    - name: Install rustc nightly
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      run: rustup toolchain install nightly
+
+    - name: Cargo deny
+      uses: EmbarkStudios/cargo-deny-action@v1
+
+    - name: Cargo check
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      run: cargo check --verbose
+
+    - name: Cargo format
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      run: cargo fmt --all -- --check --verbose
+
+    - name: Cargo clippy
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      run: cargo clippy
+
+    - name: Cargo udeps
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      run: |
+        cargo install cargo-udeps
+        cargo +nightly udeps --all-targets
+
+    - name: Cargo audit
+      uses: rustsec/audit-check@v1.4.1
+      with:
+        token: ${{ inputs.github_token }}


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Add a common step for advanced cargo checks: `fmt`, `clippy`, `udeps` (unused dependencies), `audit`, `deny`.

## Why ❔

Related to:
* [CPR-1738](https://linear.app/matterlabs/issue/CPR-1738/add-cargo-fmt-and-cargo-clippy-to-rust-repos)
* [CPR-1301](https://linear.app/matterlabs/issue/CPR-1301/static-analysis-for-rust-projects)

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Documentation comments have been added / updated.
