### PR TITLE
fix: explicitly use Linux label for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -54,7 +54,7 @@ on:
 
 jobs:
   run-integration-tests:
-    runs-on: ci-runner-compiler
+    runs-on: [ci-runner-compiler, Linux]
     timeout-minutes: 720
     container:
       image: matterlabs/llvm_runner:ubuntu22-llvm17-latest


### PR DESCRIPTION
# What ❔

Use `Linux` label explicitly for the integration tests label.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Try to workaround possible github bug with workflow calls.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
