### PR TITLE
chore: support different ccache for gnu and musl

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -92,7 +92,7 @@ runs:
         else
           LLVM_BRANCH="$(git -C ./llvm rev-parse --abbrev-ref HEAD)"
           LLVM_SHORT_SHA="$(git -C ./llvm rev-parse --short HEAD)"
-          echo "key=llvm-${LLVM_BRANCH}-${LLVM_SHORT_SHA}-${{ runner.os }}-${{ runner.arch }}" | tee -a "${GITHUB_OUTPUT}"
+          echo "key=llvm-${LLVM_BRANCH}-${LLVM_SHORT_SHA}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.target-env }}" | tee -a "${GITHUB_OUTPUT}"
         fi
 
     # CCache action requires `apt update`


### PR DESCRIPTION
# What ❔

Support different cache for GNU and Musl.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To differentiate between two hashes automatically when GNU Linux is supported now.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
