### PR TITLE
chore: add optional -coverage suffix for ccache

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -92,7 +92,10 @@ runs:
         else
           LLVM_BRANCH="$(git -C ./llvm rev-parse --abbrev-ref HEAD)"
           LLVM_SHORT_SHA="$(git -C ./llvm rev-parse --short HEAD)"
-          echo "key=llvm-${LLVM_BRANCH}-${LLVM_SHORT_SHA}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.target-env }}" | tee -a "${GITHUB_OUTPUT}"
+          if [ '${{ inputs.enable-coverage }}' = 'true' ]; then
+            COVERAGE_SUFFIX="-coverage"
+          fi
+          echo "key=llvm-${LLVM_BRANCH}-${LLVM_SHORT_SHA}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.target-env }}${COVERAGE_SUFFIX}" | tee -a "${GITHUB_OUTPUT}"
         fi
 
     # CCache action requires `apt update`


### PR DESCRIPTION
# What ❔

Add optional `-coverage` suffix for ccache to separate coverage-enabled builds from basic ones and keep both ccaches to speed up workflows.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
