### PR TITLE
fix: use upstream solc and mode=^ for EVM target

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -154,14 +154,20 @@ jobs:
       - name: Run benchmarks
         shell: bash -ex {0}
         run: |
+          MODE="${{ inputs.compiler_llvm_benchmark_mode || '^M^B3' }}"
           if [[ -n "${{ inputs.target-machine }}" && "${{ inputs.target-machine }}" != "default" ]]; then
             TARGET="--target ${{ inputs.target-machine }}"
+            # Always use upstream solc for EVM target for now
+            if [[ "${{ inputs.target-machine }}" == "EVM" ]]; then
+              UPSTREAM_SOLC="--use-upstream-solc"
+              MODE="^"
+            fi
           fi
-          ./target/release/compiler-tester ${TARGET} \
+          ./target/release/compiler-tester ${TARGET} ${UPSTREAM_SOLC} \
             --zksolc './target-zksolc/release/zksolc' \
             --zkvyper './target-zkvyper/release/zkvyper' \
             --path=${{ inputs.compiler_llvm_benchmark_path || '' }} \
-            --mode='${{ inputs.compiler_llvm_benchmark_mode || '^M^B3' }}' \
+            --mode="${MODE}" \
             --benchmark=${{ matrix.type }}.json
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -132,11 +132,15 @@ jobs:
         run: |
           if [[ -n "${{ inputs.target-machine }}" && "${{ inputs.target-machine }}" != "default" ]]; then
             TARGET="--target ${{ inputs.target-machine }}"
+            # Always use upstream solc for EVM target for now
+            if [[ "${{ inputs.target-machine }}" == "EVM" ]]; then
+              UPSTREAM_SOLC="--use-upstream-solc"
+            fi
           fi
-          ./target/release/compiler-tester ${TARGET} \
+          ./target/release/compiler-tester ${TARGET} ${UPSTREAM_SOLC} \
             --zksolc './target-zksolc/release/zksolc' \
             --zkvyper './target-zkvyper/release/zkvyper' \
-            --path '${{ inputs.path }}' ${{ inputs.extra-args }}
+            --path '${{ inputs.path }}'${EVM_MODE} ${{ inputs.extra-args }}
 
       - name: Send Slack notification
         uses: 8398a7/action-slack@v3


### PR DESCRIPTION
# What ❔

Use upstream solc for EVM target and mode=^ for benchmarks.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->