### PR TITLE
feat: support rust gha cache for cargo checks

### DIFF
--- a/.github/actions/cargo-check/action.yml
+++ b/.github/actions/cargo-check/action.yml
@@ -14,8 +14,14 @@ runs:
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       run: rustup toolchain install nightly
 
+    - name: Rust cache
+      uses: Swatinem/rust-cache@v2
+
     - name: Cargo deny
       uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        # Save cache only on push events
+        save-if: ${{ github.event_name == 'push' && github.ref_type != 'tag' }}
 
     - name: Cargo check
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}


### PR DESCRIPTION
# What ❔

Reduces the time of `cargo checks` jobs in all repositories from ~8 min down to ~1 min.

## Tests

[Without cache](https://github.com/matter-labs/era-compiler-llvm-context/actions/runs/10387059052) - 8m56s cargo check
[With cache](https://github.com/matter-labs/era-compiler-llvm-context/actions/runs/10387405933/job/28760815978) - 1m11s cargo check

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To speed up Rust workflows.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
