### PR TITLE
feat: use the toolchain enum instead of a flag

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -159,11 +159,11 @@ jobs:
             TARGET="--target ${{ inputs.target-machine }}"
             # Always use upstream solc for EVM target for now
             if [[ "${{ inputs.target-machine }}" == "EVM" ]]; then
-              UPSTREAM_SOLC="--use-upstream-solc"
+              TOOLCHAIN="--toolchain solc"
               MODE="^"
             fi
           fi
-          ./target/release/compiler-tester ${TARGET} ${UPSTREAM_SOLC} \
+          ./target/release/compiler-tester ${TARGET} ${TOOLCHAIN} \
             --zksolc './target-zksolc/release/zksolc' \
             --zkvyper './target-zkvyper/release/zkvyper' \
             --path=${{ inputs.compiler_llvm_benchmark_path || '' }} \

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -67,7 +67,7 @@ on:
         type: string
         required: false
         default: ''
-        description: 'Target machine passed via `--target` for era-compiler-tester. Available arguments: `EraVM`, `EVM`, `EVMEmulator`. Use `default` or `` to skip `--target` parameter.'
+        description: 'Target machine passed via `--target` for era-compiler-tester. Available arguments: `eravm`, `evm`. Use `default` or `` to skip this parameter.'
 
 jobs:
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -134,10 +134,10 @@ jobs:
             TARGET="--target ${{ inputs.target-machine }}"
             # Always use upstream solc for EVM target for now
             if [[ "${{ inputs.target-machine }}" == "EVM" ]]; then
-              UPSTREAM_SOLC="--use-upstream-solc"
+              TOOLCHAIN="--toolchain solc"
             fi
           fi
-          ./target/release/compiler-tester ${TARGET} ${UPSTREAM_SOLC} \
+          ./target/release/compiler-tester ${TARGET} ${TOOLCHAIN} \
             --zksolc './target-zksolc/release/zksolc' \
             --zkvyper './target-zkvyper/release/zkvyper' \
             --path '${{ inputs.path }}'${EVM_MODE} ${{ inputs.extra-args }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -20,7 +20,7 @@ on:
         type: string
         required: false
         default: ''
-        description: 'Target machine passed via `--target` for era-compiler-tester. Available arguments: `EraVM`, `EVM`, `EVMEmulator`. Use `default` or `` to skip `--target` parameter.'
+        description: 'Target machine passed via `--target` for era-compiler-tester. Available arguments: `eravm`, `evm`. Use `default` or `` to skip this parameter.'
       extra-args:
         type: string
         required: false


### PR DESCRIPTION
# What ❔

1. Uses the `--toolchain` parameter rather than a simple switch flag.
2. Rename target to lowercase to match LLVM target triples used to initialize the target machine.

## Why ❔

1. Soon we'll have 3 toolchains, so a flag is not enough.
2. Targets shall be named just like in LLVM.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
