### PR TITLE
chore: pin rust cargo cache name and save only for main execution

### DIFF
--- a/.github/actions/cargo-check/action.yml
+++ b/.github/actions/cargo-check/action.yml
@@ -16,6 +16,10 @@ runs:
 
     - name: Rust cache
       uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: "rust-cargo-cache"
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+
 
     - name: Cargo deny
       uses: EmbarkStudios/cargo-deny-action@v1


### PR DESCRIPTION
# What ❔

Save cache when running on `main` and re-use in PRs.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Now, the Rust cargo cache is generated for each PR trashing the repo cache and not re-used across PRs from the main.
This is the first step to proper cache regeneration in repositories.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
