### PR TITLE
chore: remove short sha from LLVM ccache

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -95,7 +95,7 @@ runs:
           if [ '${{ inputs.enable-coverage }}' = 'true' ]; then
             COVERAGE_SUFFIX="-coverage"
           fi
-          echo "key=llvm-${LLVM_BRANCH}-${LLVM_SHORT_SHA}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.target-env }}${COVERAGE_SUFFIX}" | tee -a "${GITHUB_OUTPUT}"
+          echo "key=llvm-${LLVM_BRANCH}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.target-env }}${COVERAGE_SUFFIX}" | tee -a "${GITHUB_OUTPUT}"
         fi
 
     # CCache action requires `apt update`


### PR DESCRIPTION
# What ❔

Remove `SHORT_SHA` from LLVM ccache entries.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Recently, we switched to `main` in the FE compiler LLVM.lock file. This resulted in the behavior when GH cache entry always had a different name and was unable to be restored. As we're switching to cache regeneration scheduling job, we remove the SHORT_SHA to make cache discoverable by all jobs in PRs.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
