### PR TITLE
fix: use base repo for reference benchmarks and head_ref for tests

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -83,20 +83,24 @@ jobs:
       options: -m 110g
     steps:
       - name: Define branches
+        shell: bash -ex {0}
         id: define-branches
         run: |
           if [ "${{ matrix.type }}" = "candidate" ]; then
             echo "compiler-tester-branch=${{ inputs.compiler_tester_candidate_branch || github.head_ref }}" | tee -a "${GITHUB_OUTPUT}"
             echo "llvm-branch=${{ inputs.compiler_llvm_candidate_branch || '' }}" | tee -a "${GITHUB_OUTPUT}"
+            echo "compiler-tester-repo=${{ inputs.compiler-tester-repo || github.event.pull_request.head.repo.full_name }}" | tee -a "${GITHUB_OUTPUT}"
           else
             echo "compiler-tester-branch=${{ inputs.compiler_tester_reference_branch || github.event.repository.default_branch }}" | tee -a "${GITHUB_OUTPUT}"
             echo "llvm-branch=${{ inputs.compiler_llvm_reference_branch || '' }}" | tee -a "${GITHUB_OUTPUT}"
+            # Always use base repo for the reference testing
+            echo "compiler-tester-repo=matter-labs/era-compiler-tester" | tee -a "${GITHUB_OUTPUT}"
           fi
 
       - name: Checkout compiler-tester
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.compiler-tester-repo }}
+          repository: ${{ steps.define-branches.outputs.compiler-tester-repo }}
           ref: ${{ steps.define-branches.outputs.compiler-tester-branch }}
           submodules: recursive
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.compiler-tester-repo }}
-          ref: ${{ inputs.compiler-tester-ref || '' }}
+          ref: ${{ inputs.compiler-tester-ref || github.head_ref || '' }}
           submodules: recursive
 
       - name: Checkout LLVM


### PR DESCRIPTION
# What ❔

* [x] For forks, always use base repo for the reference testing in benchmarks
* [x] Use `head_ref` in the base scenario for forks integration tests to not take `main` by default with `workflow_call`. This leads to issues when some other branch (not `main`) in forks repositories is used, and `main` is not rebased from the upstream repo. 

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

We have to prevent a situation when a fork repository `main` branch is not rebased, but some other branch is.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
