### PR TITLE
fix: update builder to correctly use python version

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -51,7 +51,7 @@ inputs:
   llvm-builder-version:
     description: 'Version of the LLVM builder to use.'
     required: false
-    default: '1.0.33'
+    default: '1.0.34'
   ccache-key:
     description: 'Github Actions cache key for CCache.'
     required: false

--- a/.github/actions/prepare-msys/action.yml
+++ b/.github/actions/prepare-msys/action.yml
@@ -6,7 +6,7 @@ runs:
   - name: Setup msys2
     uses: msys2/setup-msys2@v2
     with:
-      path-type: strict # Important to correctly update PATH
+      path-type: inherit # Important to correctly update PATH
       install: >-
         base-devel
         git
@@ -23,4 +23,4 @@ runs:
   - name: Prepare env
     shell: 'msys2 {0}'
     run: |
-      echo "export PATH=/c/Users/runneradmin/.cargo/bin:/mingw64/bin:/usr/bin:/usr/local/bin" >> ${HOME}/.bash_profile
+      echo "export PATH=/c/Users/runneradmin/.cargo/bin:/mingw64/bin:${PATH}" >> ${HOME}/.bash_profile


### PR DESCRIPTION
# What ❔

* [x] Updates builder to v1.0.34.
* [x] Fixes msys path variable. 

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To fix more python issues. For more info: https://github.com/matter-labs/era-compiler-llvm-builder/pull/41

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
