### PR TITLE
fix: use unique artifacts json depending on target

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -66,8 +66,8 @@ on:
       target-machine:
         type: string
         required: false
-        default: ''
-        description: 'Target machine passed via `--target` for era-compiler-tester. Available arguments: `eravm`, `evm`. Use `default` or `` to skip this parameter.'
+        default: 'eravm'
+        description: 'Target machine passed via `--target` for era-compiler-tester. Available arguments: `eravm`, `evm`.'
 
 jobs:
 
@@ -172,13 +172,13 @@ jobs:
             --zkvyper './target-zkvyper/release/zkvyper' \
             --path=${{ inputs.compiler_llvm_benchmark_path || '' }} \
             --mode="${MODE}" \
-            --benchmark=${{ matrix.type }}${{ inputs.target-machine }}.json
+            --benchmark=${{ inputs.target-machine }}-${{ matrix.type }}.json
 
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: compiler-llvm-${{ matrix.type }}-benchmark-${{ inputs.target-machine }}
-          path: ${{ matrix.type }}${{ inputs.target-machine }}.json
+          name: compiler-llvm-${{ inputs.target-machine }}-${{ matrix.type }}-benchmark
+          path: ${{ inputs.target-machine }}-${{ matrix.type }}.json
 
   analysis:
     name: "Benchmark comparison"
@@ -199,14 +199,14 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: compiler-llvm-*
+          pattern: compiler-llvm-${{ inputs.target-machine }}*
           merge-multiple: true
 
       - name: Comparing the LLVM framework benchmark results
         run: |
           cargo run --release --bin benchmark-analyzer -- \
-            --reference reference${{ inputs.target-machine }}.json \
-            --candidate candidate${{ inputs.target-machine }}.json \
+            --reference ${{ inputs.target-machine }}-reference.json \
+            --candidate ${{ inputs.target-machine }}-candidate.json \
             --output-file result.txt
 
       - name: Posting the LLVM benchmark results to the summary

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -172,13 +172,13 @@ jobs:
             --zkvyper './target-zkvyper/release/zkvyper' \
             --path=${{ inputs.compiler_llvm_benchmark_path || '' }} \
             --mode="${MODE}" \
-            --benchmark=${{ matrix.type }}.json
+            --benchmark=${{ matrix.type }}${{ inputs.target-machine }}.json
 
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: compiler-llvm-${{ matrix.type }}-benchmark-${{ inputs.target-machine }}
-          path: ${{ matrix.type }}.json
+          path: ${{ matrix.type }}${{ inputs.target-machine }}.json
 
   analysis:
     name: "Benchmark comparison"
@@ -205,7 +205,9 @@ jobs:
       - name: Comparing the LLVM framework benchmark results
         run: |
           cargo run --release --bin benchmark-analyzer -- \
-            --reference reference.json --candidate candidate.json --output-file result.txt
+            --reference reference${{ inputs.target-machine }}.json \
+            --candidate candidate${{ inputs.target-machine }}.json \
+            --output-file result.txt
 
       - name: Posting the LLVM benchmark results to the summary
         run: |

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -19,8 +19,8 @@ on:
       target-machine:
         type: string
         required: false
-        default: ''
-        description: 'Target machine passed via `--target` for era-compiler-tester. Available arguments: `eravm`, `evm`. Use `default` or `` to skip this parameter.'
+        default: 'eravm'
+        description: 'Target machine passed via `--target` for era-compiler-tester. Available arguments: `eravm`, `evm`.'
       extra-args:
         type: string
         required: false


### PR DESCRIPTION
# What ❔

Fix benchmarks json.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

`evm` and `eravm` benchmark results JSONs were mixed up rewriting each other.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
