### PR TITLE
fix: execute rust unit tests in debug mode

### DIFF
--- a/.github/actions/rust-unit-tests/action.yml
+++ b/.github/actions/rust-unit-tests/action.yml
@@ -16,7 +16,7 @@ inputs:
   build-type:
     description: 'Type of build: release or debug.'
     required: false
-    default: 'release'
+    default: 'debug'
   enable-coverage:
     description: 'Enable code coverage.'
     required: false


### PR DESCRIPTION
# What ❔

Execute Rust unit tests in debug mode.

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
