### PR TITLE
fix: install locked dependencies for cargo-udeps

### DIFF
--- a/.github/actions/cargo-check/action.yml
+++ b/.github/actions/cargo-check/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: Cargo udeps
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
       run: |
-        cargo install cargo-udeps
+        cargo install cargo-udeps --locked
         cargo +nightly udeps --all-targets
 
     - name: Cargo audit


### PR DESCRIPTION
# What ❔

Install `--locked` dependencies for `cargo-udeps`.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To fix build issues in `cargo-checks` workflow.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
