### PR TITLE
feat: change ccache to sccache to cache rust too

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -87,7 +87,8 @@ runs:
 
     - name: Install LLVM builder
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
-      run: cargo install compiler-llvm-builder@${{ inputs.llvm-builder-version }}
+      run: |
+        cargo install compiler-llvm-builder --git https://github.com/matter-labs/era-compiler-llvm-builder --branch aba-support-sccache
 
     - name: Clone LLVM framework
       if: inputs.clone-llvm == 'true'
@@ -141,6 +142,7 @@ runs:
         max-size: "2G"
         verbose: 2
         save: ${{ steps.ccache-save.outputs.save }}
+        variant: "sccache"
 
     # CCACHE_BASEDIR, CCACHE_NOHASHDIR, and CCACHE_COMPILERCHECK
     # are allowing to cache compiler output across different
@@ -169,4 +171,4 @@ runs:
         fi
 
         zksync-llvm build --target-env ${{ inputs.target-env }} ${DEFAULT_TARGET} --build-type ${{ inputs.build-type }} \
-          --use-ccache ${{ inputs.builder-extra-args }} ${ENABLE_TESTS} ${ENABLE_VALGRIND} ${ENABLE_ASSERTIONS} ${ENABLE_COVERAGE} ${LLVM_PROJECTS} ${ENABLE_RTTI} ${SANITIZER} ${EXTRA_ARGS}
+          --use-ccache ${{ inputs.builder-extra-args }} --ccache-variant=sccache ${ENABLE_TESTS} ${ENABLE_VALGRIND} ${ENABLE_ASSERTIONS} ${ENABLE_COVERAGE} ${LLVM_PROJECTS} ${ENABLE_RTTI} ${SANITIZER} ${EXTRA_ARGS}


### PR DESCRIPTION
# What ❔

Change ccache to sccache.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

`sccache` is the default one used by upstream LLVM project and it also provides a capability to cache Rust compilation. Trying to use it to see if it improves `zksolc`, `zkvyper` build times.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
