### PR TITLE
feat: add common release-plz workflow for crates.io releases

### DIFF
--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -1,0 +1,69 @@
+name: Release-plz
+
+on:
+  workflow_call:
+    inputs:
+      github_token:
+        type: string
+        description: 'GitHub token'
+        required: true
+      cargo_registry_token:
+        type: string
+        description: 'Cargo registry token'
+        required: true
+      run_tests:
+        type: boolean
+        description: 'Run tests before release'
+        required: false
+        default: false
+
+jobs:
+
+  # Release unpublished packages.
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run tests before release
+        if: ${{ inputs.run_tests == true || inputs.run_tests == 'true' }}
+        run: cargo test
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ inputs.github_token }}
+          CARGO_REGISTRY_TOKEN: ${{ inputs.cargo_registry_token }}
+
+  # Create a PR with the new versions and changelog, preparing the next release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ inputs.github_token }}
+          CARGO_REGISTRY_TOKEN: ${{ inputs.cargo_registry_token }}


### PR DESCRIPTION
# What ❔

Add common `crates.io` release workflow.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To be able to release crates to `crates.io` in CI.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
