### PR TITLE
chore: change github_token to gh_token because its reserved

### DIFF
--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -3,7 +3,7 @@ name: Release-plz
 on:
   workflow_call:
     secrets:
-      github_token:
+      gh_token:
         description: 'GitHub token'
         required: true
       cargo_registry_token:
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.github_token }}
+          token: ${{ secrets.gh_token }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -41,7 +41,7 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
+          GITHUB_TOKEN: ${{ secrets.gh_token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.cargo_registry_token }}
 
   # Create a PR with the new versions and changelog, preparing the next release.
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.github_token }}
+          token: ${{ secrets.gh_token }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -66,5 +66,5 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
+          GITHUB_TOKEN: ${{ secrets.gh_token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.cargo_registry_token }}


### PR DESCRIPTION
# What ❔

Change `github_token` to `gh_token` because `github_token` is a reserved name.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
