### PR TITLE
fix: add macos arm64 into exceptions for rust cache

### DIFF
--- a/.github/actions/rust-unit-tests/action.yml
+++ b/.github/actions/rust-unit-tests/action.yml
@@ -35,7 +35,7 @@ runs:
 
     - name: Rust cache
       if: ${{ !(runner.os == 'macOS' && runner.arch == 'arm64') }}
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@v1
       with:
         shared-key: "rust-cargo-cache-${{ runner.os }}-${{ runner.arch }}"
         save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/actions/rust-unit-tests/action.yml
+++ b/.github/actions/rust-unit-tests/action.yml
@@ -35,7 +35,7 @@ runs:
 
     - name: Rust cache
       if: ${{ !(runner.os == 'macOS' && runner.arch == 'arm64') }}
-      uses: Swatinem/rust-cache@v1
+      uses: Swatinem/rust-cache@v2
       with:
         shared-key: "rust-cargo-cache-${{ runner.os }}-${{ runner.arch }}"
         save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/actions/rust-unit-tests/action.yml
+++ b/.github/actions/rust-unit-tests/action.yml
@@ -34,6 +34,7 @@ runs:
         echo "target=--target ${{ inputs.target }}" >> "${GITHUB_OUTPUT}"
 
     - name: Rust cache
+      if: ${{ !(runner.os == 'macOS' && runner.arch == 'arm64') }}
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: "rust-cargo-cache-${{ runner.os }}-${{ runner.arch }}"


### PR DESCRIPTION
# What ❔

Add self hosted runner into exceptions to save and restore cache due to removal of `cargo` binaries.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

https://github.com/Swatinem/rust-cache/issues/16

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
