### PR TITLE
fix: ccache settings for benchmarks and int tests

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,11 +3,6 @@ name: Benchmarks
 on:
   workflow_call:
     inputs:
-      llvm_build_type:
-        type: string
-        description: "LLVM build type: debug | release"
-        required: false
-        default: "release"
       compiler_tester_reference_branch:
         type: string
         description: "compiler-tester branch to use as a benchmark reference"
@@ -38,6 +33,11 @@ on:
         description: "Path filter for compiler-llvm benchmarks"
         required: false
         default: ""
+      ccache-key:
+        type: string
+        description: 'Github Actions cache key for CCache.'
+        required: false
+        default: ''
       ccache-key-type:
         type: string
         required: false
@@ -119,7 +119,9 @@ jobs:
         uses: matter-labs/era-compiler-ci/.github/actions/build-llvm@main
         with:
           clone-llvm: ${{ steps.define-branches.outputs.llvm-branch == '' && 'true' || 'false' }}
-          enable-assertions: true
+          enable-assertions: false
+          build-type: 'Release'
+          ccache-key: ${{ inputs.ccache-key }}
           ccache-key-type: ${{ inputs.ccache-key-type }}
 
       - name: Build compiler-tester

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -36,6 +36,11 @@ on:
         required: false
         default: ''
         description: 'custom solc version to use for integration tests'
+      ccache-key:
+        type: string
+        description: 'Github Actions cache key for CCache.'
+        required: false
+        default: ''
       ccache-key-type:
         type: string
         required: false
@@ -103,7 +108,9 @@ jobs:
         with:
           enable-tests: true
           enable-assertions: true
+          build-type: 'RelWithDebInfo'
           clone-llvm: ${{ inputs.llvm-ref == '' && 'true' || 'false' }}
+          ccache-key: ${{ inputs.ccache-key }}
           ccache-key-type: ${{ inputs.ccache-key-type }}
 
       - name: Integration tests


### PR DESCRIPTION
# What ❔

* [x] Fix ccache settings for benchmarks and int tests.
* [x] Use `RelWithDebInfo` for integration tests, and `Release` LLVM build types for benchmarks. 

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To properly regen cache in LLVM repo and use it in benchmarks and integration tests.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
