### PR TITLE
fix: use pr branch in analysis instead of main

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -217,7 +217,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.compiler-tester-repo }}
-          ref: ${{ inputs.compiler_tester_candidate_branch || 'main' }}
           submodules: recursive
 
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
# What ❔

Use the PR branch in the `analysis` job instead of `main` for benchmarks.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To be able to test updates and fixes in `benchmark-analyzer` in PRs.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
