### PR TITLE
fix: E+ 0.8 mode in the lnt benchmarking table

### DIFF
--- a/.github/workflows/lnt.yml
+++ b/.github/workflows/lnt.yml
@@ -231,7 +231,7 @@ jobs:
             fi
             # Extract metadata
             TARGET=$(echo "$MAIN_MACHINE" | grep -o 'eravm\|evm' || echo "")
-            MODE=$(echo "$MAIN_MACHINE" | grep -o 'Y+M3B3\|Y+MzB3\|E+M3B3_0.8\|E+MzB3_0.8\|Y+' || echo "")
+            MODE=$(echo "$MAIN_MACHINE" | grep -o 'Y+M3B3\|Y+MzB3\|E+M3B3_0.8\|E+MzB3_0.8\|Y+\|E+_0.8' || echo "")
             TOOLCHAIN=$(echo "$MAIN_MACHINE" | grep -o 'solc\|ir-llvm' || echo "")
             ENVIRONMENT=$(echo "$MAIN_MACHINE" | grep -o 'EVMInterpreter\|REVM' || echo "")
             if [[ -z "$ENVIRONMENT" ]]; then


### PR DESCRIPTION
# What ❔

Fix E+ 0.8 mode in the lnt benchmarking table.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To properly display the MODE in the results for E+.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
