### PR TITLE
chore: always upload solc binary to artifacts

### DIFF
--- a/.github/actions/build-solc/action.yml
+++ b/.github/actions/build-solc/action.yml
@@ -36,7 +36,7 @@ inputs:
   upload-testing-binary:
     description: 'Upload testing binary.'
     required: false
-    default: 'false'
+    default: 'true'
 
 runs:
   using: "composite"


### PR DESCRIPTION
# What ❔

Always upload solc binary to artifacts.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To remove necessity to update this parameter in CI for all solc branches.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
