### PR TITLE
chore: use github-hosted stable macos arm64 runner

### DIFF
--- a/.github/workflows/solc-build-release.yml
+++ b/.github/workflows/solc-build-release.yml
@@ -95,7 +95,7 @@ jobs:
             runner: macos-latest-large
             release-suffix: macosx-amd64
           - name: "MacOS arm64"
-            runner: [self-hosted, macOS, ARM64]
+            runner: macos-latest-xlarge
             release-suffix: macosx-arm64
           - name: "Linux x86"
             runner: matterlabs-ci-runner-high-performance


### PR DESCRIPTION
# What ❔

Use github-hosted stable macos arm64 runner instead of self-hosted machine.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To fix all issues with clone and clean up for era-solidity and other repositories with complex submodules git cloning.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
