### PR TITLE
fix: use v2.17 of ccache action due to action save bug

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -133,7 +133,7 @@ runs:
         fi
 
     - name: Set up compiler cache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5
       env:
         CCACHE_BASEDIR: ${{ github.workspace }}
         CCACHE_NOHASHDIR: "true"


### PR DESCRIPTION
# What ❔

Use v2.17 release of ccache action.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Due to https://github.com/hendrikmuhs/ccache-action/pull/301/files changes, if the action used twice, it doesn't save the cache properly.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
