### PR TITLE
fix: use lld linker on windows only during build

### DIFF
--- a/.github/actions/build-rust/action.yml
+++ b/.github/actions/build-rust/action.yml
@@ -51,7 +51,7 @@ runs:
         if [ '${{ inputs.enable-coverage }}' = 'true' ]; then
           export RUSTFLAGS="${RUSTFLAGS} -C instrument-coverage"
         fi
-        if [[ "${RUNNER_OS}" == "Windows" ]] || [[ "${RUNNER_OS}" == "Linux" ]]; then
+        if [[ "${RUNNER_OS}" == "Windows" ]]; then
           export RUSTFLAGS="${RUSTFLAGS} -C link-arg=-fuse-ld=lld"
         fi
         cargo ${BUILD_STD_LIB} build ${RELEASE} ${{ steps.build-target.outputs.target }}


### PR DESCRIPTION
# What ❔

* [x] Use lld linker on windows only during build.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Follow-up with https://github.com/matter-labs/era-compiler-ci/pull/69 for the rust builds.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
