### PR TITLE
fix: return -fuse-ld=lld for Rust build and test

### DIFF
--- a/.github/actions/build-rust/action.yml
+++ b/.github/actions/build-rust/action.yml
@@ -51,7 +51,7 @@ runs:
         if [ '${{ inputs.enable-coverage }}' = 'true' ]; then
           export RUSTFLAGS="${RUSTFLAGS} -C instrument-coverage"
         fi
-        if [[ "${RUNNER_OS}" == "Windows" ]]; then
+        if [[ "${RUNNER_OS}" == "Windows" ]] || [[ "${RUNNER_OS}" == "Linux" ]]; then
           export RUSTFLAGS="${RUSTFLAGS} -C link-arg=-fuse-ld=lld"
         fi
         cargo ${BUILD_STD_LIB} build ${RELEASE} ${{ steps.build-target.outputs.target }}

--- a/.github/actions/rust-unit-tests/action.yml
+++ b/.github/actions/rust-unit-tests/action.yml
@@ -81,7 +81,7 @@ runs:
           export ASAN_SYMBOLIZER_PATH=$(which llvm-symbolizer)
         fi
         # Use LLD on Windows to properly link with libstdc++.
-        if [ ${RUNNER_OS} = Windows ]; then
+        if [[ ${RUNNER_OS} = Windows ]] || [[ ${RUNNER_OS} = Linux ]]; then
           export RUSTFLAGS="${RUSTFLAGS} -C link-arg=-fuse-ld=lld"
         fi
         cargo test ${{ steps.build-target.outputs.target }} -- -Z unstable-options \


### PR DESCRIPTION
# What ❔

To recover `solx` linkage with Boost and solc statically, there is only way to use `lld` for Linux.
The issue with `zksolc` and `zkvyper` linkage can also be fixed by using `lld` natively removing `rust-lld` linker from the config.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
