### PR TITLE
chore: fix typo in rust unit tests

### DIFF
--- a/.github/actions/rust-unit-tests/action.yml
+++ b/.github/actions/rust-unit-tests/action.yml
@@ -61,7 +61,7 @@ runs:
           TEST_COMMAND="llvm-cov --all-features --workspace --lcov --output-path lcov.info"
         fi
         # Use LLD on Windows to properly link with libstdc++.
-        if [[ ${RUNNER_OS} = Windows ]] || [[ ${RUNNER_OS} = Linux ]]; then; then
+        if [[ ${RUNNER_OS} = Windows ]] || [[ ${RUNNER_OS} = Linux ]]; then
           export RUSTFLAGS="${RUSTFLAGS} -C link-arg=-fuse-ld=lld"
         fi
         cargo ${TEST_COMMAND} --release ${{ steps.build-target.outputs.target }} -- -Z unstable-options \


### PR DESCRIPTION
# What ❔

fix typo in rust unit tests

