### PR TITLE
fix: use mgw15 suffix for boost on windows

### DIFF
--- a/.github/actions/build-solc/action.yml
+++ b/.github/actions/build-solc/action.yml
@@ -135,7 +135,7 @@ runs:
           export LDFLAGS='-fuse-ld=lld -lbcrypt -lwsock32 -static -Wl,--stack,67108864'
           BOOST_SHORT_VERSION=${BOOST_VERSION%??}
           BOOST_INCLUDEDIR="${PWD}/boost/include/boost-${BOOST_SHORT_VERSION}"
-          BOOST_CMAKE_FLAGS="${BOOST_CMAKE_FLAGS} -DBoost_COMPILER=-mgw14 -DBoost_ARCHITECTURE=-x64"
+          BOOST_CMAKE_FLAGS="${BOOST_CMAKE_FLAGS} -DBoost_COMPILER=-mgw15 -DBoost_ARCHITECTURE=-x64"
         fi
         mkdir -p ./build
         cd ./build


### PR DESCRIPTION
# What ❔

Use mgw15 suffix for boost on windows.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

After packages update on mingw, it's gcc15 now.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
