### PR TITLE
fix: use prebuilt solc running evm ir-llvm benchmarks and tests

### DIFF
--- a/.github/actions/build-solc/action.yml
+++ b/.github/actions/build-solc/action.yml
@@ -166,6 +166,20 @@ runs:
         name: solc-${{ steps.solc-version.outputs.version }}-${{ inputs.build-type }}-${{ runner.os }}-${{ runner.arch }}
         path: ${{ inputs.working-dir }}/build/solc/solc-${{ steps.solc-version.outputs.version }}-${{ inputs.build-type }}${{ runner.os == 'Windows' && '.exe' || '' }}
 
+    - name: Upload build directory for testing
+      if: ${{ inputs.upload-testing-binary == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-solc-${{ steps.solc-version.outputs.version }}-${{ inputs.build-type }}-${{ runner.os }}-${{ runner.arch }}
+        path: ${{ inputs.working-dir }}/build
+
+    - name: Upload boost for testing
+      if: ${{ inputs.upload-testing-binary == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: boost-${{ steps.solc-version.outputs.version }}-${{ inputs.build-type }}-${{ runner.os }}-${{ runner.arch }}
+        path: ${{ inputs.working-dir }}/boost
+
     - name: Prepare binary
       working-directory: ${{ inputs.working-dir }}
       if: inputs.release-suffix != ''

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -119,12 +119,30 @@ jobs:
           submodules: recursive
 
       - name: Building solc
-        if: inputs.target-machine == 'evm' && inputs.toolchain == 'ir-llvm'
+        if: inputs.target-machine == 'evm' && inputs.toolchain == 'ir-llvm' && inputs.custom-solc-run-id == ''
         uses: matter-labs/era-compiler-ci/.github/actions/build-solc@main
         with:
           cmake-build-type: RelWithDebInfo
           working-dir: 'era-solidity'
           upload-testing-binary: false
+
+      - name: Download prebuilt solc
+        if: inputs.target-machine == 'evm' && inputs.toolchain == 'ir-llvm' && inputs.custom-solc-run-id != ''
+        uses: actions/download-artifact@v4
+        with:
+          pattern: build-solc-${{ inputs.custom-solc-version}}-${{ matrix.type }}-*
+          path: ./era-solidity/build
+          run-id: ${{ inputs.custom-solc-run-id }}
+          merge-multiple: true
+
+      - name: Download prebuilt boost
+        if: inputs.target-machine == 'evm' && inputs.toolchain == 'ir-llvm' && inputs.custom-solc-run-id != ''
+        uses: actions/download-artifact@v4
+        with:
+          pattern: boost-${{ inputs.custom-solc-version}}-${{ matrix.type }}-*
+          path: ./era-solidity/boost/
+          run-id: ${{ inputs.custom-solc-run-id }}
+          merge-multiple: true
 
       - name: Checkout LLVM
         if: steps.define-branches.outputs.llvm-branch != ''

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -106,12 +106,21 @@ jobs:
         uses: matter-labs/era-compiler-ci/.github/actions/prepare-msys@v1
 
       - name: Building solc
-        if: inputs.target-machine == 'evm' && inputs.toolchain == 'ir-llvm'
+        if: inputs.target-machine == 'evm' && inputs.toolchain == 'ir-llvm' && inputs.custom-solc-run-id == ''
         uses: matter-labs/era-compiler-ci/.github/actions/build-solc@main
         with:
           cmake-build-type: RelWithDebInfo
           working-dir: 'era-solidity'
           upload-testing-binary: false
+
+      - name: Download prebuilt solc
+        if: inputs.target-machine == 'evm' && inputs.toolchain == 'ir-llvm' && inputs.custom-solc-run-id != ''
+        uses: actions/download-artifact@v4
+        with:
+          pattern: build-solc-*
+          path: ./era-solidity/build/
+          run-id: ${{ inputs.custom-solc-run-id }}
+          merge-multiple: true
 
       # An issue prevents to correctly use the same version of composite actions from `workflow_call`
       # https://github.com/actions/toolkit/issues/1264


### PR DESCRIPTION
# What ❔

Use prebuilt solc libs and boost for running evm ir-llvm benchmarks and tests.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Tests

Tested here: https://github.com/matter-labs/era-solidity/pull/1054

## Why ❔

Before, `evm` benchmarks were not correct, because default branch of `solc` was always prebuilt and used during benchmarks.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
