### PR TITLE
chore: update windows runner

### DIFF
--- a/.github/workflows/solc-build-release.yml
+++ b/.github/workflows/solc-build-release.yml
@@ -106,7 +106,7 @@ jobs:
             image: ${{ needs.setup.outputs.use-new-tools == 'true' && 'ghcr.io/matter-labs/zksync-llvm-runner:latest' || 'matterlabs/llvm_runner:ubuntu20-llvm17-latest' }}
             release-suffix: linux-arm64
           - name: Windows
-            runner: windows-2019-github-hosted-64core
+            runner: windows-2022-github-hosted-64core
             release-suffix: windows-amd64
     runs-on: ${{ matrix.runner }}
     container:


### PR DESCRIPTION
# What ❔

* [x] Update `windows-2019-github-hosted-64core` -> `windows-2022-github-hosted-64core` 

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

It looks like `windows-2019-github-hosted-64core` is deprecated and cannot be used anymore although it's still in our runners' list.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
