### PR TITLE
fix: remove wrong stderr in sizes json report

### DIFF
--- a/.github/workflows/forge-benchmarks.yaml
+++ b/.github/workflows/forge-benchmarks.yaml
@@ -315,7 +315,7 @@ jobs:
                 COMPILE_TIME=$(awk -v ms="${elapsed_ms}" 'BEGIN { printf "%.3f\n", ms / 1000 }')
 
                 # Get build size report
-                forge build --optimize --sizes ${USE_SOLX} ${VIA_IR_OPTION} --json > ${BUILD_SIZES_JSON} 2>&1 || true
+                forge build --optimize --sizes ${USE_SOLX} ${VIA_IR_OPTION} --json > ${BUILD_SIZES_JSON} 2>/dev/null || true
 
                 if [[ ${COMPILER} == *solx* ]]; then
                   TOOLCHAIN="${COMPILER}${VIA_IR_SUFFIX}"


### PR DESCRIPTION
# What ❔

Remove wrong stderr in sizes json report.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

JSON report with build sizes should be used only from stdout, stderr was wrongly added and breaking it in some corner cases where it was not empty.

Redirect `stderr` to /dev/null in this case, because errors and warnings already saved on the previous build step.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
