### PR TITLE
chore: disable cargo audit runs by default

### DIFF
--- a/.github/actions/cargo-check/action.yml
+++ b/.github/actions/cargo-check/action.yml
@@ -5,6 +5,10 @@ inputs:
   github_token:
     description: 'GitHub token for cargo audit.'
     required: true
+  run_cargo_audit:
+    description: 'Whether to run cargo audit.'
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -44,6 +48,7 @@ runs:
         cargo +nightly udeps --all-targets
 
     - name: Cargo audit
+      if: ${{ inputs.run_cargo_audit == 'true' }}
       uses: rustsec/audit-check@v1.4.1
       with:
         token: ${{ inputs.github_token }}


### PR DESCRIPTION
# What ❔

Disable `cargo-audit` checks by default.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
